### PR TITLE
C wrapper for ANEOS

### DIFF
--- a/src/ANEOSINIT.f
+++ b/src/ANEOSINIT.f
@@ -1,0 +1,28 @@
+      SUBROUTINE ANEOSINIT(INPUT)
+C**********************************************************************
+C     INITIALIZE ANEOS FOR THE C WRAPPER
+C**********************************************************************
+      PARAMETER (NMATMAX=21)
+      PARAMETER (NUMMAT=1)
+      DIMENSION IZETL(NMATMAX)
+      COMMON /FILEOS/ KLST, KINP
+
+      CHARACTER*(*) INPUT
+
+C     INITIALIZE INPUT AND OUTPUT FILES
+      KLST=10
+      KINP=12
+      OPEN(KINP,FILE=INPUT,STATUS='OLD')
+      OPEN(KLST,FILE='ANEOS.OUTPUT')
+
+C     INITIALIZE ANEOS
+      IZETL(1)=-1
+      CALL ANEOS2 (1,NUMMAT,0,IZETL)
+
+
+C     CLOSE INPUT AND OUTPUT FILES
+      CLOSE(KINP)
+      CLOSE(KLST)
+
+      RETURN
+      END

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,15 @@
 FC = gfortran
 FCFLAGS = -O3 
+CC = cc
+CFLAGS = -O3 -Wall
 AR = ar
 ARFLAGS = -cru
 LDFLAGS = 
 LIBRARY = libaneos.a
 PROGRAM = m-aneos
 PROGOBJECTS = ANEOSTEST.o EOS.o
+CWRAPPER = testaneoswrapper
+CWRAPPEROBJECTS = testaneoswrapper.o aneos.o ANEOSINIT.o
 LIBOBJECTS = ANDATA.o \
 	ANDEBY.o \
 	ANE2PH.o \
@@ -44,6 +48,9 @@ LIBOBJECTS = ANDATA.o \
 %.o: %.f
 	$(FC) -c $(FCFLAGS) $<
 
+%.o: %.c
+	$(CC) -c $(CFLAGS) $<
+
 default: $(PROGRAM)
 
 $(LIBRARY): $(LIBOBJECTS) 
@@ -52,6 +59,9 @@ $(LIBRARY): $(LIBOBJECTS)
 
 $(PROGRAM): $(PROGOBJECTS) $(LIBRARY)
 	$(FC) $(FCFLAGS) -o $(PROGRAM) $(PROGOBJECTS) $(LIBRARY)
+
+$(CWRAPPER): $(CWRAPPEROBJECTS) $(LIBRARY)
+	$(FC) $(FCFLAGS) -o $(CWRAPPER) $(CWRAPPEROBJECTS) $(LIBRARY)
 
 install:
 	cp ../input/quartz_.input ../example/ANEOS.INPUT

--- a/src/aneos.c
+++ b/src/aneos.c
@@ -104,13 +104,14 @@ void callaneos_cgs (
 	int* kpa, double* rhoL, double* rhoH, double* ion
 ) {
     double T_in_eV;
+    const double KelvinIneV = 1.16045e4;
 	const int n = 1;
 
     // Make sure that the library was initalized.
     assert(bANEOSInitialized);
 
     // Convert from K to eV
-    T_in_eV = T/KELVIN_IN_EV;
+    T_in_eV = T/KelvinIneV;
 
 	aneosv_(
 		&n, &T_in_eV, &rho, &mat, p, u, S, cv, dpdt, dpdrho, fkros,
@@ -118,6 +119,6 @@ void callaneos_cgs (
 	);
 
     // Convert the output to K
-    *S /= KELVIN_IN_EV;
-    *cv /= KELVIN_IN_EV;
+    *S /= KelvinIneV;
+    *cv /= KelvinIneV;
 }

--- a/src/aneos.c
+++ b/src/aneos.c
@@ -1,0 +1,123 @@
+/*
+ * This is a C wrapper to the Fortran functions of the ANEOS equation of state.
+ * It is based on a C++ code that was provided by F. Benitez.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "aneos.h"
+
+/*
+ * Define a global variable that stores if ANEOS was properly initialized.
+ */
+static int bANEOSInitialized = FALSE;
+
+/**
+ * Initialize the ANEOS library.
+ *
+ * This is a wrapper arround the ANEOSINIT Fortran subroutine.
+ */
+void initaneos(char *matFilename) {
+	if ( bANEOSInitialized ) {
+		return;
+	}
+
+	bANEOSInitialized = TRUE;
+	fprintf(stderr,"Initializing ANEOS with input file %s.\n", matFilename);
+
+	// Use aneos.input for ANEOS
+    assert(matFilename != NULL);
+    assert(strlen(matFilename) > 0);
+    
+    // At some point it would be smart to check, if the desired file exists.
+	aneosinit_( matFilename, strlen(matFilename) );
+}
+
+/**
+ * Compute the ANEOS equation of state for given ( T, rho, mat ) values.
+ *
+ * This is a wrapper around ANEOSV Fortran subroutine.
+ * The library will be initialized is not already done, so there is no
+ * requirement to call initaneos() before this function.
+ * All units are CGS-eV.
+ *
+ * @param T         Temperature (input)
+ * @param rho       Density (input)
+ * @param mat       Material number, as defined in the input file (input)
+ * @param p         Pressure (output)
+ * @param u         Specific internal energy (output)
+ * @param S         Specific entropy (output)
+ * @param cv        Specific heat capacity at constant volume (output)
+ * @param dpdt      Temperature derivative of the pressure (output)
+ * @param dpdrho    Density derivative of the pressure (output)
+ * @param fkros     Rossland mean opacity (output)
+ * @param cs        Speed of sound (output)
+ * @param kpa       Phase (output)
+ * @param rhoL      Density of the lower phase, for multi-phase states (output)
+ * @param rhoH      Density of the higher phase, for multi-phase states (output)
+ * @param ion       Ionisation number (output)
+ */
+void callaneos (
+	const double T, const double rho, const int mat,
+	double* p, double* u, double* S, double* cv,
+	double* dpdt, double* dpdrho, double* fkros, double* cs,
+	int* kpa, double* rhoL, double* rhoH, double* ion
+) {
+	const int n = 1;
+
+//	initaneos();
+    // Make sure that the library was initalized.
+    assert(bANEOSInitialized);
+
+	aneosv_(
+		&n, &T, &rho, &mat, p, u, S, cv, dpdt, dpdrho, fkros,
+		cs, kpa, rhoL, rhoH, ion
+	);
+}
+
+/**
+ * Compute the ANEOS equation of state for given ( T, rho, mat ) values in CGS units.
+ *
+ * This function basically converts the input variables from cgs and Kelvin to cgs and
+ * eV then calls the EOS and converts the results back to cgs/K.
+ *
+ * @param T         Temperature [K] (input)
+ * @param rho       Density [g/cc] (input)
+ * @param mat       Material number, as defined in the input file (input)
+ * @param p         Pressure [erg/cc] (output)
+ * @param u         Specific internal energy [erg/g] (output)
+ * @param S         Specific entropy [erg/g/K] (output)
+ * @param cv        Specific heat capacity at constant volume [erg/g/K] (output)
+ * @param dpdt      Temperature derivative of the pressure (output)
+ * @param dpdrho    Density derivative of the pressure (output)
+ * @param fkros     Rossland mean opacity (output)
+ * @param cs        Speed of sound [cm/s] (output)
+ * @param kpa       Phase (output)
+ * @param rhoL      Density of the lower phase, for multi-phase states (output)
+ * @param rhoH      Density of the higher phase, for multi-phase states (output)
+ * @param ion       Ionisation number (output)
+ */
+void callaneos_cgs (
+	const double T, const double rho, const int mat,
+	double* p, double* u, double* S, double* cv,
+	double* dpdt, double* dpdrho, double* fkros, double* cs,
+	int* kpa, double* rhoL, double* rhoH, double* ion
+) {
+    double T_in_eV;
+	const int n = 1;
+
+    // Make sure that the library was initalized.
+    assert(bANEOSInitialized);
+
+    // Convert from K to eV
+    T_in_eV = T/KELVIN_IN_EV;
+
+	aneosv_(
+		&n, &T_in_eV, &rho, &mat, p, u, S, cv, dpdt, dpdrho, fkros,
+		cs, kpa, rhoL, rhoH, ion
+	);
+
+    // Convert the output to K
+    *S /= KELVIN_IN_EV;
+    *cv /= KELVIN_IN_EV;
+}

--- a/src/aneos.h
+++ b/src/aneos.h
@@ -1,0 +1,92 @@
+/*
+ * The header file for the ANEOS wrapper.
+ */
+#ifndef LIBANEOS_HINCLUDED
+#define LIBANEOS_HINCLUDED
+
+#define FALSE 0
+#define TRUE 1
+
+/* Convert from K to eV (1 K = 1 eV in Joule / kbolz in J) */
+#define KELVIN_IN_EV 1.16054e4
+
+/**
+ * FORTRAN subroutine "ANEOSINIT" to init ANEOS
+ */
+void aneosinit_(
+	const char*,  /// materials file
+	int           /// filename string length
+);
+
+/**
+ * FORTRAN subroutine "ANEOS" for p( rho, T, mat )
+ *
+ * This methods takes an array of items to achieve multiple calculation with
+ * the same call, the number of elements being given in the first parameter.
+ */
+void aneosv_(
+	const int*,     /// no of array elements
+	const double*,  /// T (input)
+	const double*,  /// rho (input)
+	const int*,     /// material (input)
+	double*,        /// p
+	double*,        /// E
+	double*,        /// S
+	double*,        /// c_v
+	double*,        /// dp/dT
+	double*,        /// dp/dRho
+	double*,        /// fkro (Rosseland mean opacity)
+	double*,        /// cs
+	int*,           /// phase
+	double*,        /// lower  phase density
+	double*,        /// higher phase density
+	double*         /// ionization number
+);
+
+/**
+ * Initialize the ANEOS library.
+ *
+ * This is a wrapper arround aneosinit Fortran subroutine.
+ */
+void initaneos(char *matFilename);
+
+/**
+ * Compute the ANEOS equation of state for given ( T, rho, mat ) values.
+ *
+ * This is a wrapper around ANEOSV Fortran subroutine.
+ * All units are CGS-eV.
+ *
+ * @param T Temperature (input)
+ * @param rho Density (input)
+ * @param mat Material number, as defined in the input file (input)
+ * @param p Pressure (output)
+ * @param u Specific internal energy (output)
+ * @param S Specific entropy (output)
+ * @param cv Specific heat capacity at constant volume (output)
+ * @param dpdt Temperature derivative of the pressure (output)
+ * @param dpdrho Density derivative of the pressure (output)
+ * @param fkros Rossland mean opacity (output)
+ * @param cs Speed of sound (output)
+ * @param kpa Phase (output)
+ * @param rhoL Density of the lower phase, for multi-phase states (output)
+ * @param rhoH Density of the higher phase, for multi-phase states (output)
+ * @param ion Ionisation number (output)
+ */
+void callaneos (
+	const double T, const double rho, const int mat,
+	double* p, double* u, double* S, double* cv,
+	double* dpdt, double* dpdrho, double* fkros, double* cs,
+	int* kpa, double* rhoL, double* rhoH, double* ion
+);
+
+/*
+ * The same function as callaneos() but temperature has to be provided in K not eV.
+ */
+void callaneos_cgs (
+	const double T, const double rho, const int mat,
+	double* p, double* u, double* S, double* cv,
+	double* dpdt, double* dpdrho, double* fkros, double* cs,
+	int* kpa, double* rhoL, double* rhoH, double* ion
+);
+#endif
+

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -25,6 +25,7 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     double T0;
     int nRho;
     int nT;
+    double tmp;
     FILE *fp;
     int iRet;
     int i;
@@ -68,14 +69,19 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     iRet = fscanf(fp, "%lf", &T0);
     //if (iRet != 1) return FAIL;
     assert(iRet == 1);
+    
+    iRet = fscanf(fp, "%lf", &tmp);
+    nRho = (int) tmp;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
+    assert(nRho > 0);
 
-    iRet = fscanf(fp, "%d", &nRho);
-    //if (iRet != 1) return FAIL;
-    assert(iRet == 1);
  
-    iRet = fscanf(fp, "%d", &nT);
+    iRet = fscanf(fp, "%lf", &tmp);
+    nT = (int) tmp;
     //if (iRet != 1) return FAIL;
     assert(iRet == 1);
+    assert(nT > 0);
 
     /* Allocate memory and read rho and T. */
     rho = calloc(nRho, sizeof(double));

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
     int i;
 
     /* Test if reading the file tablegrid.txt works. */
-    if (!ReadTableGrid("tablegrid.txt", rhoAxis, TAxis, &nRho, &nT)) {
+    if (ReadTableGrid("tablegrid.txt", rhoAxis, TAxis, &nRho, &nT)) {
         fprintf(stderr, "Failed reading tablegrid.txt.\n");
         exit(1);
     }

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -357,7 +357,7 @@ int main(int argc, char **argv) {
     nwds2 = 2+Table->nRho+Table->nT+Table->nRho*Table->nT*4;
 
     /* Write the header. */
-    fprintf(fp, " INDEX     MATID = %7i   NWDS = %8i\n", (int) Table->SesameId, nwds);
+    fprintf(fp, " INDEX     MATID =%7i   NWDS = %8i\n", (int) Table->SesameId, nwds);
     fprintf(fp, "%16.8E%16.8E%16.8E%16.8E%16.8E\n", Table->SesameId, Table->Date, Table->Date,
                                                     Table->Version, (double) nTables);
     fprintf(fp, "%16.8E%16.8E%16.8E%16.8E\n", (double) Table1, (double) Table2, (double) nwds1, (double) nwds2);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -282,6 +282,8 @@ int main(int argc, char **argv) {
     int nwds2;
     int nValues;
     FILE *fp;
+    /* Convert from eV to K. */
+    double Tconv = 1.16045e4;
     int i, j;
 
 #if 0
@@ -310,7 +312,8 @@ int main(int argc, char **argv) {
 
     fprintf(stderr, "rho_min= %16.8E rho_max= %16.8E\n", Table->rho[0], Table->rho[Table->nRho-1]);
     fprintf(stderr, "T_min= %16.8E T_max= %16.8E\n", Table->T[0], Table->T[Table->nT-1]);
-    
+
+#if 0 
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
             rho = Table->rho[i];
@@ -342,6 +345,39 @@ int main(int argc, char **argv) {
             Table->phase[i][j] = iPhase;
         }
     }
+#endif
+
+    for (i=0; i<Table->nRho; i++) {
+        for (j=0; j<Table->nT; j++) {
+
+            callaneos_cgs(Table->T[j], Table->rho[i], iMat, &Table->P[i][j], &Table->u[i][j],
+                    &Table->s[i][j], &Table->cv[i][j], &dPdT, &dPdrho, &fkros, &cs,
+                    &Table->phase[i][j], &rhoL, &rhoH, &ion);
+
+#if 0
+            /* Convert specific entropy from ergs/g/K to MJ/kg/K. */
+            s *= 1e-10;
+            callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL,
+                    &rhoH, &ion);
+#endif
+            /* Limit the pressure. */
+            if (fabs(p) < 1e-20) p = 1e-20;
+
+            /* Convert pressure from cgs to GPa. */
+            Table->P[i][j] *= 1e-10;
+
+            /* Convert specific internal energy from erg/g to MJ/kg. */
+            Table->u[i][j] *= 1e-10;
+
+            /* Convert specific entropy from ergs/g/K to MJ/kg/K. */
+            Table->s[i][j] *= 1e-10;
+
+            /* Convert specific heat capacity from erg/g/K to MJ/kg/K. */
+            Table->cv[i][j] *= 1e-10;
+        }
+    }
+
+
 
     /*
      * Write the SESAME table.
@@ -395,6 +431,7 @@ int main(int argc, char **argv) {
     /* Specific entropy */
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
+
             fprintf(fp, "%16.8E", Table->s[i][j]);
             nValues++;
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -257,6 +257,12 @@ int main(int argc, char **argv) {
     double ion;
     /* EOS table. */
     struct ANEOSTable *Table;
+    int nwds;
+    int nTables;
+    int Table1;
+    int Table2;
+    int nwds1;
+    int nwds2;
     int i;
 
 #if 0
@@ -278,7 +284,19 @@ int main(int argc, char **argv) {
     Table = ANEOSTableInit("tablegrid.txt");
     assert(Table != NULL);
 
+    fprintf(stderr, "Open input file.\n");
     fprintf(stderr, "nRho= %i nT= %i\n", Table->nRho, Table->nT);
+
+    for (i=0; i<
+
+
+    /* Write the EOS table. */
+    nwds = 9;
+    nTables = 2;
+    Table1 = 201;
+    Table2 = 301;
+    nwds1 = 5;
+    nwds2 = 2+Table->nRho+Table->nT+Table->nRho*Table->nT*3;
 
     exit(1);
     callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL, &rhoH,

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -77,10 +77,6 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     //if (iRet != 1) return FAIL;
     assert(iRet == 1);
 
-    iRet = fscanf(fp, "%lf", &K0);
-    //if (iRet != 1) return FAIL;
-    assert(iRet == 1);
-
     /* Allocate memory and read rho and T. */
     rho = calloc(nRho, sizeof(double));
     assert(rho != NULL);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -14,7 +14,7 @@
 #define SUCCESS 0
 #define FAIL -1
 
-int ReadTableGrid(char *chFile, int *nRho, int *nT) {
+int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     double sesameid;
     double date;
     double version;
@@ -27,55 +27,71 @@ int ReadTableGrid(char *chFile, int *nRho, int *nT) {
     int nT;
     FILE *fp;
     int iRet;
-    
+    int i;
+
+    if (rho != NULL) free(rho);
+    if (T != NULL) free(T);
+
     fp = fopen(chFile, "r");
-    if (fp == NULL)
-        return FAIL;
+    if (fp == NULL) return FAIL;
 
     /* Read the file. */
     iRet = fscanf(fp, "%lf", &sesameid);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &date);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &version);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &fmn);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &fmw);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &rho0);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &T0);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
 
-    iRet = fscanf(fp, "%lf", &nRho);
-    if (iRet != 1)
-        return FAIL;
+    iRet = fscanf(fp, "%d", &nRho);
+    if (iRet != 1) return FAIL;
  
-    iRet = fscanf(fp, "%lf", &nT);
-    if (iRet != 1)
-        return FAIL;
+    iRet = fscanf(fp, "%d", &nT);
+    if (iRet != 1) return FAIL;
 
     iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1)
-        return FAIL;
+    if (iRet != 1) return FAIL;
+
+    /* Allocate memory and read rho and T. */
+    rho = calloc(nRho, sizeof(double));
+    assert(rho != NULL);
+
+    T = calloc(nT, sizeof(double));
+    assert(rho != NULL);
+
+    for (i=0; i<nRho; i++) {
+        iRet = fscanf(fp, "%lf", &rho[i]);
+        if (iRet != 1) return FAIL;
+    }
+
+    for (i=0; i<nT; i++) {
+        iRet = fscanf(fp, "%lf", &T[i]);
+        if (iRet != 1) return FAIL;
+    }
+
+    fclose(fp);
+
+    *pnRho = nRho;
+    *pnT = nT;
+
+    return SUCCESS;
 }
 
 int main(int argc, char **argv) {
@@ -99,6 +115,19 @@ int main(int argc, char **argv) {
     /* EOS table. */
     int nRho;
     int nT;
+    double *rhoAxis;
+    double *TAxis;
+    int i;
+
+    /* Test if reading the file tablegrid.txt works. */
+    if (!ReadTableGrid("tablegrid.txt", rhoAxis, TAxis, &nRho, &nT)) {
+        fprintf(stderr, "Failed reading tablegrid.txt.\n");
+        exit(1);
+    }
+    
+    fprintf(stderr, "nRho= %i nT= %i\n", nRho, nT);
+    
+    exit(1);
 
     if (argc != 4) {
         fprintf(stderr, "Usage: aneoscall <rho> <T> <iMat>\n");

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -590,7 +590,6 @@ int main(int argc, char **argv) {
     }
 
     /* Specific internal energy */
-
     for (j=0; j<Table->nT; j++) {
         for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->u[i][j]);
@@ -601,7 +600,6 @@ int main(int argc, char **argv) {
     }
 
     /* Helmholtz free energy */
-
     for (j=0; j<Table->nT; j++) {
         for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->u[i][j]-Table->T[j]*Table->s[i][j]);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -263,6 +263,7 @@ int main(int argc, char **argv) {
     int Table2;
     int nwds1;
     int nwds2;
+    FILE *fp;
     int i;
 
 #if 0
@@ -287,16 +288,46 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Open input file.\n");
     fprintf(stderr, "nRho= %i nT= %i\n", Table->nRho, Table->nT);
 
-    for (i=0; i<
+    fprintf(stderr, "rho_min= %16.8E rho_max= %16.8E\n", Table->rho[0], Table->rho[Table->nRho-1]);
+    fprintf(stderr, "T_min= %16.8E T_max= %16.8E\n", Table->T[0], Table->T[Table->nT-1]);
 
+    /*
+     * Write the standard (short) SESAME table.
+     */
+    fp = fopen("NEW-SESAME-STD.NEW", "w");
+    assert(fp != NULL);
 
-    /* Write the EOS table. */
     nwds = 9;
     nTables = 2;
     Table1 = 201;
     Table2 = 301;
     nwds1 = 5;
     nwds2 = 2+Table->nRho+Table->nT+Table->nRho*Table->nT*3;
+
+    /* Write the header. */
+    fprintf(fp, " INDEX     MATID = %7i   NWDS = %8i\n", (int) Table->SesameId, nwds);
+    fprintf(fp, "%16.8E%16.8E%16.8E%16.8E%16.8E\n", Table->SesameId, Table->Date, Table->Date,
+                                                    Table->Version, nTables);
+    fprintf(fp, "%16.8E%16.8E%16.8E%16.8E\n", (double) Table1, (double) Table2, (double) nwds1, (double) nwds2);
+
+    /* Table 1. */
+    fprintf(fp, " RECORD     TYPE =%5i     NWDS = %8i\n", Table1, nwds1);
+    fprintf(fp, "%16.8E%16.8E%16.8E%16.8E%16.8E\n", Table->fmn, Table->fmw, Table->rho0, Table->K0,
+                                                    Table->T0);
+    /* Table 2. */
+    fprintf(fp, " RECORD     TYPE =%5i     NWDS = %8i\n", Table2, nwds2);
+
+    /* Number of grid points in rho and T. */
+    fprintf(fp, "%16.8E%16.8E", (double) Table->nRho, (double) Table->nT);
+
+    /* Print rho and T axis. */
+    fprintf(fp, "%16.8E%16.8E%16.8E\n", Table->rho[0], Table->rho[1], Table->rho[2]);
+
+    for (i=3; i<Table->nRho; i++) {
+        fprintf(fp, "%16.8E", Table->rho[i]);
+        /* Print a new line after every 5 grid points. */
+        if (((i + 3) % 5) == 0) fprintf(fp, "\n");
+    }
 
     exit(1);
     callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL, &rhoH,

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -522,7 +522,7 @@ int main(int argc, char **argv) {
     /* Phase */
     for (j=0; j<Table->nT; j++) {
         for (i=0; i<Table->nRho; i++) {
-            fprintf(fp, "%15.8E", (double) Table->phase[i][j]);
+            fprintf(fp, "%16.8E", (double) Table->phase[i][j]);
             nValues++;
 
             if ((nValues % 5) == 0) fprintf(fp, "\n");

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
     fprintf(stderr, "rho_min= %16.8E rho_max= %16.8E\n", Table->rho[0], Table->rho[Table->nRho-1]);
     fprintf(stderr, "T_min= %16.8E T_max= %16.8E\n", Table->T[0], Table->T[Table->nT-1]);
 
-#if 0 
+//#if 0 
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
             rho = Table->rho[i];
@@ -345,9 +345,9 @@ int main(int argc, char **argv) {
             Table->phase[i][j] = iPhase;
         }
     }
-#endif
+//#endif
 
-//#if 0
+#if 0
     i = 0;
     j = 0;
 
@@ -405,7 +405,8 @@ int main(int argc, char **argv) {
     fprintf(stderr, "\n"); 
 
     exit(1);
-//#endif
+#endif
+#if 0
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
 
@@ -435,7 +436,7 @@ int main(int argc, char **argv) {
             Table->cv[i][j] *= 1e-10;
         }
     }
-
+#endif
 
 
     /*
@@ -488,8 +489,8 @@ int main(int argc, char **argv) {
     }
 
     /* Specific entropy */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
 
             fprintf(fp, "%16.8E", Table->s[i][j]);
             nValues++;
@@ -499,8 +500,8 @@ int main(int argc, char **argv) {
     }
 
     /* Sound speed */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->cs[i][j]);
             nValues++;
 
@@ -509,8 +510,8 @@ int main(int argc, char **argv) {
     }
 
     /* Specific heat capacity */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->cv[i][j]);
             nValues++;
 
@@ -519,8 +520,8 @@ int main(int argc, char **argv) {
     }
 
     /* Phase */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%15.8E", (double) Table->phase[i][j]);
             nValues++;
 
@@ -569,7 +570,7 @@ int main(int argc, char **argv) {
         /* Print a new line after every 5 grid points. */
         if ((nValues % 5) == 0) fprintf(fp, "\n");
     }
-    
+
     /* Temperature */
     for (i=0; i<Table->nT; i++) {
         fprintf(fp, "%16.8E", Table->T[i]);
@@ -579,8 +580,8 @@ int main(int argc, char **argv) {
     }
 
     /* Pressure */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->P[i][j]);
             nValues++;
 
@@ -589,8 +590,9 @@ int main(int argc, char **argv) {
     }
 
     /* Specific internal energy */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->u[i][j]);
             nValues++;
 
@@ -599,8 +601,9 @@ int main(int argc, char **argv) {
     }
 
     /* Helmholtz free energy */
-    for (i=0; i<Table->nRho; i++) {
-        for (j=0; j<Table->nT; j++) {
+
+    for (j=0; j<Table->nT; j++) {
+        for (i=0; i<Table->nRho; i++) {
             fprintf(fp, "%16.8E", Table->u[i][j]-Table->T[j]*Table->s[i][j]);
             nValues++;
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -33,41 +33,53 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     if (T != NULL) free(T);
 
     fp = fopen(chFile, "r");
-    if (fp == NULL) return FAIL;
+    //if (fp == NULL) return FAIL;
+    assert(fp != NULL);
 
     /* Read the file. */
     iRet = fscanf(fp, "%lf", &sesameid);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &date);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &version);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &fmn);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &fmw);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &rho0);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &T0);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%d", &nRho);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
  
     iRet = fscanf(fp, "%d", &nT);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1) return FAIL;
+    //if (iRet != 1) return FAIL;
+    assert(iRet == 1);
 
     /* Allocate memory and read rho and T. */
     rho = calloc(nRho, sizeof(double));
@@ -78,12 +90,14 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
 
     for (i=0; i<nRho; i++) {
         iRet = fscanf(fp, "%lf", &rho[i]);
-        if (iRet != 1) return FAIL;
+        //if (iRet != 1) return FAIL;
+        assert(iRet == 1);
     }
 
     for (i=0; i<nT; i++) {
         iRet = fscanf(fp, "%lf", &T[i]);
-        if (iRet != 1) return FAIL;
+        //if (iRet != 1) return FAIL;
+        assert(iRet == 1);
     }
 
     fclose(fp);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -263,6 +263,7 @@ int main(int argc, char **argv) {
     int Table2;
     int nwds1;
     int nwds2;
+    int nValues;
     FILE *fp;
     int i;
 
@@ -321,12 +322,22 @@ int main(int argc, char **argv) {
     fprintf(fp, "%16.8E%16.8E", (double) Table->nRho, (double) Table->nT);
 
     /* Print rho and T axis. */
-    fprintf(fp, "%16.8E%16.8E%16.8E\n", Table->rho[0], Table->rho[1], Table->rho[2]);
+    nValues = 2;
 
-    for (i=3; i<Table->nRho; i++) {
+    for (i=0; i<Table->nRho; i++) {
         fprintf(fp, "%16.8E", Table->rho[i]);
+        nValues++;
+
         /* Print a new line after every 5 grid points. */
-        if (((i + 3) % 5) == 0) fprintf(fp, "\n");
+        if ((nValues % 5) == 0) fprintf(fp, "\n");
+    }
+
+    for (i=0; i<Table->nT; i++) {
+        fprintf(fp, "%16.8E", Table->T[i]);
+        nValues++;
+
+        /* Print a new line after every 5 grid points. */
+        if ((nValues % 5) == 0) fprintf(fp, "\n");
     }
 
     exit(1);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -347,27 +347,63 @@ int main(int argc, char **argv) {
     }
 #endif
 
-#if 0
+//#if 0
     i = 0;
     j = 0;
 
     fprintf(stderr, "i= %i, j= %i, T= %16.8E K = %16.8E eV, rho= %16.8E\n", i, j, Table->T[j],
             Table->T[j]/Tconv, Table->rho[i]);
 
+    /* Call ANEOS in the usual units. */
+    fprintf(stderr, "Call ANEOS: T= %16.8E eV, rho= %16.8E\n", Table->T[j]/Tconv, Table->rho[i]);
+
     callaneos(Table->T[j]/Tconv, Table->rho[i], iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs,
                   &iPhase, &rhoL, &rhoH, &ion);
     
-    fprintf(stderr, "P = %16.8E\n", p);
-    fprintf(stderr, "u = %16.8E\n", u);
-    fprintf(stderr, "s = %16.8E\n", s);
-    fprintf(stderr, "cs = %16.8E\n", cs);
-    fprintf(stderr, "cv = %16.8E\n", cv);
+    fprintf(stderr, "ANEOS units: cgs and eV\n");
+    fprintf(stderr, "P = %16.8E [erg/cc]\n", p);
+    fprintf(stderr, "u = %16.8E [erg/g]\n", u);
+    fprintf(stderr, "s = %16.8E [erg/g/eV] \n", s);
+    fprintf(stderr, "cs = %16.8E [cm/s]\n", cs);
+    fprintf(stderr, "cv = %16.8E [erg/g/eV]\n", cv);
     fprintf(stderr, "phase = %i\n", iPhase);
-   
+    fprintf(stderr, "\n"); 
 
+    /* Call ANEOS in cgs and K. */
+    fprintf(stderr, "Call ANEOS: T= %16.8E K, rho= %16.8E\n", Table->T[j], Table->rho[i]);
+    
+    callaneos_cgs(Table->T[j], Table->rho[i], iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs,
+                  &iPhase, &rhoL, &rhoH, &ion);
+      
+    fprintf(stderr, "ANEOS units: cgs and K\n");
+    fprintf(stderr, "P = %16.8E [erg/cc]\n", p);
+    fprintf(stderr, "u = %16.8E [erg/g]\n", u);
+    fprintf(stderr, "s = %16.8E [erg/g/K] \n", s);
+    fprintf(stderr, "cs = %16.8E [cm/s]\n", cs);
+    fprintf(stderr, "cv = %16.8E [erg/g/K]\n", cv);
+    fprintf(stderr, "phase = %i\n", iPhase);
+    fprintf(stderr, "\n"); 
+
+    /* Convert pressure from cgs to GPa. */
+    p *= 1e-10;
+    /* Convert specific internal energy from erg/g to MJ/kg. */
+    u *= 1e-10;
+    /* Convert specific entropy from ergs/g/K to MJ/kg/K. */
+    s *= 1e-10;
+    /* Convert specific heat capacity from erg/g/K to MJ/kg/K. */
+    cv *= 1e-10;
+
+    fprintf(stderr, "ANEOS units: SESAME table\n");
+    fprintf(stderr, "P = %16.8E [GPa]\n", p);
+    fprintf(stderr, "u = %16.8E [MJ/kg]\n", u);
+    fprintf(stderr, "s = %16.8E [MJ/kg/K] \n", s);
+    fprintf(stderr, "cs = %16.8E [cm/s]\n", cs);
+    fprintf(stderr, "cv = %16.8E [MJ/kg/K]\n", cv);
+    fprintf(stderr, "phase = %i\n", iPhase);
+    fprintf(stderr, "\n"); 
 
     exit(1);
-#endif
+//#endif
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -386,6 +386,47 @@ int main(int argc, char **argv) {
         if ((nValues % 5) == 0) fprintf(fp, "\n");
     }
 
+    /* Specific entropy */
+    for (i=0; i<Table->nRho; i++) {
+        for (j=0; j<Table->nT; j++) {
+            fprintf(fp, "%16.8E", Table->s[i][j]);
+            nValues++;
+
+            if ((nValues % 5) == 0) fprintf(fp, "\n");
+        }
+    }
+
+    /* Sound speed */
+    for (i=0; i<Table->nRho; i++) {
+        for (j=0; j<Table->nT; j++) {
+            fprintf(fp, "%16.8E", Table->cs[i][j]);
+            nValues++;
+
+            if ((nValues % 5) == 0) fprintf(fp, "\n");
+        }
+    }
+
+    /* Specific heat capacity */
+    for (i=0; i<Table->nRho; i++) {
+        for (j=0; j<Table->nT; j++) {
+            fprintf(fp, "%16.8E", Table->cv[i][j]);
+            nValues++;
+
+            if ((nValues % 5) == 0) fprintf(fp, "\n");
+        }
+    }
+
+    /* Phase */
+    for (i=0; i<Table->nRho; i++) {
+        for (j=0; j<Table->nT; j++) {
+            fprintf(fp, "%16.8E", (double) Table->phase[i][j]);
+            nValues++;
+
+            if ((nValues % 5) == 0) fprintf(fp, "\n");
+        }
+    }
+    
+    fclose(fp);
 
     exit(1);
     callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL, &rhoH,

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -107,6 +107,7 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     *pnRho = nRho;
     *pnT = nT;
 
+#if 0
     /* Write the data to tablegrid.new.*/
     fp = fopen("tablegrid.new", "w");
     assert(fp != NULL);
@@ -132,6 +133,7 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     }
 
     fclose(fp);
+#endif
     return SUCCESS;
 }
 
@@ -160,7 +162,7 @@ int main(int argc, char **argv) {
     double *TAxis;
     int i;
 
-    /* Test if reading the file tablegrid.txt works. */
+    /* Reading the file tablegrid.txt. */
     if (ReadTableGrid("tablegrid.txt", rhoAxis, TAxis, &nRho, &nT)) {
         fprintf(stderr, "Failed reading tablegrid.txt.\n");
         exit(1);
@@ -168,23 +170,10 @@ int main(int argc, char **argv) {
     
     fprintf(stderr, "nRho= %i nT= %i\n", nRho, nT);
     
-    exit(1);
-
-    if (argc != 4) {
-        fprintf(stderr, "Usage: aneoscall <rho> <T> <iMat>\n");
-        exit(1);
-    }
-
-    rho = atof(argv[1]);
-    T = atof(argv[2]);
-    iMat = atoi(argv[3]);
-
-    assert(rho > 0.0);
-    assert(T > 0.0);
-    assert(iMat >= 0);
-
-    fprintf(stderr, "ANEOS: Initializing material...\n");
+    fprintf(stderr, "ANEOS: Initializing material.\n");
     initaneos(matFilename);
+    fprintf(stderr, "ANEOS: Done.\n");
+
 
     callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL, &rhoH,
                   &ion);

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -107,6 +107,31 @@ int ReadTableGrid(char *chFile, double *rho, double *T, int *pnRho, int *pnT) {
     *pnRho = nRho;
     *pnT = nT;
 
+    /* Write the data to tablegrid.new.*/
+    fp = fopen("tablegrid.new", "w");
+    assert(fp != NULL);
+
+    /* Write the data to the file. */
+    fprintf(fp, "%11.6e\n", sesameid);
+    fprintf(fp, "%11.6e\n", date);
+    fprintf(fp, "%11.6e\n", version);
+    fprintf(fp, "%11.6e\n", fmn);
+    fprintf(fp, "%11.6e\n", fmw);
+    fprintf(fp, "%11.6e\n", rho0);
+    fprintf(fp, "%11.6e\n", K0);
+    fprintf(fp, "%11.6e\n", T0);
+    fprintf(fp, "%11.6e\n", (double) nRho);
+    fprintf(fp, "%11.6e\n", (double) nT);
+
+    for (i=0; i<nRho; i++) {
+        fprintf(fp, "%11.6e\n", rho[i]);
+    }
+
+    for (i=0; i<nT; i++) {
+        fprintf(fp, "%11.6e\n", T[i]);
+    }
+
+    fclose(fp);
     return SUCCESS;
 }
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -347,6 +347,27 @@ int main(int argc, char **argv) {
     }
 #endif
 
+#if 0
+    i = 0;
+    j = 0;
+
+    fprintf(stderr, "i= %i, j= %i, T= %16.8E K = %16.8E eV, rho= %16.8E\n", i, j, Table->T[j],
+            Table->T[j]/Tconv, Table->rho[i]);
+
+    callaneos(Table->T[j]/Tconv, Table->rho[i], iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs,
+                  &iPhase, &rhoL, &rhoH, &ion);
+    
+    fprintf(stderr, "P = %16.8E\n", p);
+    fprintf(stderr, "u = %16.8E\n", u);
+    fprintf(stderr, "s = %16.8E\n", s);
+    fprintf(stderr, "cs = %16.8E\n", cs);
+    fprintf(stderr, "cv = %16.8E\n", cv);
+    fprintf(stderr, "phase = %i\n", iPhase);
+   
+
+
+    exit(1);
+#endif
     for (i=0; i<Table->nRho; i++) {
         for (j=0; j<Table->nT; j++) {
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -354,6 +354,8 @@ int main(int argc, char **argv) {
     fprintf(stderr, "i= %i, j= %i, T= %16.8E K = %16.8E eV, rho= %16.8E\n", i, j, Table->T[j],
             Table->T[j]/Tconv, Table->rho[i]);
 
+    fprintf(stderr, "T= %16.8E eV (normal), T= %16.8E eV (define) frac= %16.8E\n", Table->T[j]/Tconv, Table->T[j]/KELVIN_IN_EV, Table->T[j]/Tconv/Table->T[j]/KELVIN_IN_EV);
+
     /* Call ANEOS in the usual units. */
     fprintf(stderr, "Call ANEOS: T= %16.8E eV, rho= %16.8E\n", Table->T[j]/Tconv, Table->rho[i]);
 

--- a/src/testaneoswrapper.c
+++ b/src/testaneoswrapper.c
@@ -1,0 +1,75 @@
+/*
+ * Calculate all thermodynamic variables from ANEOS.
+ *
+ * Author:   Christian Reinhardt
+ * Created:  29.07.2020
+ * Modified:  
+ */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "aneos.h"
+
+int main(int argc, char **argv) {
+    double rho;
+    double T;
+    int iMat;
+    char matFilename[256] = "ANEOS.INPUT";
+    // Uncomment below to use M-ANEOS
+    //char matFilename[256] = "maneos.in";
+    double p;
+    double u;
+    double s;
+    double cv;
+    double dPdT;
+    double dPdrho;
+    double fkros;
+    double cs;
+    int iPhase;
+    double rhoL;
+    double rhoH;
+    double ion;
+
+    if (argc != 4) {
+        fprintf(stderr, "Usage: aneoscall <rho> <T> <iMat>\n");
+        exit(1);
+    }
+
+    rho = atof(argv[1]);
+    T = atof(argv[2]);
+    iMat = atoi(argv[3]);
+
+    assert(rho > 0.0);
+    assert(T > 0.0);
+    assert(iMat >= 0);
+
+    fprintf(stderr, "ANEOS: Initializing material...\n");
+    initaneos(matFilename);
+
+    callaneos_cgs(T, rho, iMat, &p, &u, &s, &cv, &dPdT, &dPdrho, &fkros, &cs, &iPhase, &rhoL, &rhoH,
+                  &ion);
+
+    printf("Input:\n");
+    printf("rho = %15.7E\n", rho);
+    printf("T   = %15.7E\n", T);
+    printf("iMat= %i\n", iMat);
+    printf("\n");
+
+    printf("Output:\n");
+    printf("p      = %15.7E\n", p);
+    printf("u      = %15.7E\n", u);
+    printf("s      = %15.7E\n", s);
+    printf("cv     = %15.7E\n", cv);
+    printf("dPdT   = %15.7E\n", dPdT);
+    printf("dPdrho = %15.7E\n", dPdrho);
+    printf("fkros  = %15.7E\n", fkros);
+    printf("cs     = %15.7E\n", cs);
+    printf("iPhase = %i\n", iPhase);
+    printf("rhoL   = %15.7E\n", rhoL);
+    printf("rhoH   = %15.7E\n", rhoH);
+    printf("ion    = %15.7E\n", ion);
+    printf("\n");
+
+    return 0;
+}

--- a/src/testcallaneos.c
+++ b/src/testcallaneos.c
@@ -1,8 +1,8 @@
 /*
- * Generate an EOS table and compare to the result of the Fortran code.
+ * Calculate all thermodynamic variables from ANEOS.
  *
  * Author:   Christian Reinhardt
- * Created:  06.06.2021
+ * Created:  29.07.2020
  * Modified:  
  */
 #include <math.h>
@@ -11,79 +11,13 @@
 #include <assert.h>
 #include "aneos.h"
 
-#define SUCCESS 0
-#define FAIL -1
-
-int ReadTableGrid(char *chFile, int *nRho, int *nT) {
-    double sesameid;
-    double date;
-    double version;
-    double fmn;
-    double fmw;
-    double rho0;
-    double K0;
-    double T0;
-    int nRho;
-    int nT;
-    FILE *fp;
-    int iRet;
-    
-    fp = fopen(chFile, "r");
-    if (fp == NULL)
-        return FAIL;
-
-    /* Read the file. */
-    iRet = fscanf(fp, "%lf", &sesameid);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &date);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &version);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &fmn);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &fmw);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &rho0);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &T0);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &nRho);
-    if (iRet != 1)
-        return FAIL;
- 
-    iRet = fscanf(fp, "%lf", &nT);
-    if (iRet != 1)
-        return FAIL;
-
-    iRet = fscanf(fp, "%lf", &K0);
-    if (iRet != 1)
-        return FAIL;
-}
-
 int main(int argc, char **argv) {
-    char matFilename[256] = "ANEOS.INPUT";
-    /* Variables for aneoscall(). */
     double rho;
     double T;
-    int iMat = 1;
+    int iMat;
+    char matFilename[256] = "ANEOS.INPUT";
+    // Uncomment below to use M-ANEOS
+    //char matFilename[256] = "maneos.in";
     double p;
     double u;
     double s;
@@ -96,9 +30,6 @@ int main(int argc, char **argv) {
     double rhoL;
     double rhoH;
     double ion;
-    /* EOS table. */
-    int nRho;
-    int nT;
 
     if (argc != 4) {
         fprintf(stderr, "Usage: aneoscall <rho> <T> <iMat>\n");


### PR DESCRIPTION
I added a C wrapper to facilitate the use of the ANEOS library in C programs.

files: ANEOSINIT.f, aneos.c, aneos.h

initaneos(): Call ANEOSINIT() in ANEOSINIT.f with the name of the input file and set a global flag indicating that the library was initialized. Please note that in its current from initaneos() assumes that the input file contains only one material and that the material id is -1. Future versions could allow the user to provide an arbitrary number of material ids when calling the function.

callaneos(): Call ANEOSV() in ANEOSV.F with the required input parameters (number of EOS calls, density, temperature and material id). Note that currently the number of EOS calls is hard coded but in principle it would be possible to provide a vector.

callaneos_cgs(): In principle the same function as callaneos() but the input and output parameters are in cgs and Kelvin (not eV).

An example of how to use the wrapper is provided with the C program test aneoswrapper.c. The program initializes ANEOS and generates the same SESAME tables as ANEOSTEST.f.

Compile:

make testaneoswrapper


